### PR TITLE
docs(core): remove `in` operator from unsupported operators table

### DIFF
--- a/adev/src/content/guide/templates/expression-syntax.md
+++ b/adev/src/content/guide/templates/expression-syntax.md
@@ -87,7 +87,6 @@ NOTE: Optional chaining behaves differently from the standard JavaScript version
 | Object destructuring  | `const { name } = person`         |
 | Array destructuring   | `const [firstItem] = items`       |
 | Comma operator        | `x = (x++, x)`                    |
-| in                    | `'model' in car`                  |
 | typeof                | `typeof 42`                       |
 | void                  | `void 1`                          |
 | instanceof            | `car instanceof Automobile`       |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/contributing-docs/commit-message-guidelines.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.dev application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The `in` operator is listed twice:
- [in the supported operators table](https://github.com/angular/angular/blob/4c14503efbd040b23d3a194760ece6a37584d0a1/adev/src/content/guide/templates/expression-syntax.md?plain=1#L69)
- [in the unsupported operators table](https://github.com/angular/angular/blob/4c14503efbd040b23d3a194760ece6a37584d0a1/adev/src/content/guide/templates/expression-syntax.md?plain=1#L90)


## What is the new behavior?

The `in` operator is listed once:
- in the supported operators table
## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
